### PR TITLE
Fix rolling text timing and card size consistency

### DIFF
--- a/script.js
+++ b/script.js
@@ -299,9 +299,10 @@ function addAnimationDelays(array, ms) {
         ? aboutHeadingContainer.querySelector('.stickySectionIndicator-heading')
         : null;
 
-      const angleStep = 10;   // degrees between each line on the cylinder
+      const angleStep = 20;   // degrees between each line on the cylinder
       const isMobile = window.innerWidth <= 599;
-      const radius = isMobile ? 70 : 100; // cylinder radius in px (smaller on mobile)
+      const radius = isMobile ? 80 : 120; // cylinder radius in px (smaller on mobile)
+      const deadZone = 0.15;  // first 15% of scroll is static (image visible before text rolls)
 
       function update() {
         const rect = section.getBoundingClientRect();
@@ -316,11 +317,11 @@ function addAnimationDelays(array, ms) {
         // Heading: fade when rolling text is active, HIDE when it's done
         // so the heading can't appear in the trailing empty space
         if (aboutHeadingContainer) {
-          if (progress >= 0.85) {
+          if (progress >= 0.90) {
             // Rolling text nearly done — hide heading completely
             aboutHeadingContainer.style.visibility = 'hidden';
-          } else if (progress > 0.02) {
-            // Rolling text active — fade heading, covered by z-index anyway
+          } else if (progress > deadZone) {
+            // Rolling text active — fade heading
             aboutHeadingContainer.style.visibility = '';
             aboutHeading.classList.add('faded');
           } else {
@@ -330,8 +331,11 @@ function addAnimationDelays(array, ms) {
           }
         }
 
+        // Apply dead zone: first 15% of scroll keeps text static on line 0
+        const adjustedProgress = progress <= deadZone ? 0 : (progress - deadZone) / (1 - deadZone);
+
         // Which line index is "centered" right now
-        const centerIndex = progress * (numLines - 1);
+        const centerIndex = adjustedProgress * (numLines - 1);
 
         lines.forEach(function(line, i) {
           var diff = i - centerIndex;

--- a/styles.css
+++ b/styles.css
@@ -477,7 +477,8 @@ body {
     top: 0;
     height: 100vh;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    padding-top: 12vh;
     z-index: 1;
   }
 
@@ -727,12 +728,12 @@ body {
       max-height: 300px;
     }
 
-    /* Poster frame responsive */
+    /* Poster frame responsive — consistent size across sections */
     .poster-frame {
-      width: 70vw;
-      height: calc(70vw * 1.33);
-      max-width: 280px;
-      max-height: 373px;
+      width: 55vw;
+      height: calc(55vw * 1.33);
+      max-width: 240px;
+      max-height: 320px;
       padding: 12px;
     }
 
@@ -740,12 +741,12 @@ body {
       justify-content: flex-start;
     }
 
-    /* Smaller poster frames for carousel slides on mobile */
+    /* Project carousel slides match the same poster size */
     .project-slide .poster-frame {
       width: 55vw;
       height: calc(55vw * 1.33);
-      max-width: 220px;
-      max-height: 293px;
+      max-width: 240px;
+      max-height: 320px;
       padding: 10px;
     }
 
@@ -755,7 +756,7 @@ body {
 
     .projects-swiper .swiper-slide {
       width: 55vw;
-      max-width: 220px;
+      max-width: 240px;
     }
   }
   


### PR DESCRIPTION
Rolling text:
- Increase angleStep from 10° to 20° so only ~4-5 lines visible at once instead of all 14 stacking on screen simultaneously
- Add 15% dead zone at start of scroll so image is visible before text starts rolling
- Increase cylinder radius for better 3D depth effect
- Align sticky content to top with padding instead of vertical center to eliminate the large empty gap above the profile image

Card sizes:
- Unify poster-frame sizes on mobile: both Building and Projects sections now use 55vw / max-width 240px (Building was 70vw/280px, Projects was 55vw/220px — visually inconsistent)

https://claude.ai/code/session_01U5jtXUP7RMFdKULRQu5pEy