### PR TITLE
Fix rolling text pacing on mobile to match desktop experience

### DIFF
--- a/script.js
+++ b/script.js
@@ -302,7 +302,7 @@ function addAnimationDelays(array, ms) {
       const angleStep = 20;   // degrees between each line on the cylinder
       const isMobile = window.innerWidth <= 599;
       const radius = isMobile ? 80 : 120; // cylinder radius in px (smaller on mobile)
-      const deadZone = 0.15;  // first 15% of scroll is static (image visible before text rolls)
+      const deadZone = isMobile ? 0.30 : 0.15;  // mobile needs bigger dead zone so image settles first
 
       function update() {
         const rect = section.getBoundingClientRect();

--- a/styles.css
+++ b/styles.css
@@ -694,7 +694,7 @@ body {
     }
 
     .rolling-text-section {
-      height: 160vh;
+      height: 280vh;
     }
     .rolling-text-sticky .row {
       flex-direction: column;


### PR DESCRIPTION
Mobile section was 160vh (60vh scroll range) — text raced through 14 lines at ~32px per line, impossible to read. Desktop was 220vh (120vh range, ~75px/line) which felt right.

Changes:
- Increase mobile section height 160vh → 280vh (180vh scroll range)
- Increase mobile dead zone 15% → 30% (54vh of scrolling before text starts rolling, so the image fully settles into view first)
- Effective text animation: 126vh for 14 lines ≈ 79px per line, matching the desktop ~75px/line pacing

https://claude.ai/code/session_01U5jtXUP7RMFdKULRQu5pEy