### PR TITLE
Fix project poster frames being smaller than building poster frames o…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -629,11 +629,11 @@ body {
       max-width: 300px;
     }
     .project-slide .poster-frame {
-      width: 35vw;
-      height: calc(35vw * 1.33);
-      max-width: 260px;
-      max-height: 346px;
-      padding: 12px;
+      width: 40vw;
+      height: calc(40vw * 1.33);
+      max-width: 300px;
+      max-height: 400px;
+      padding: 14px;
     }
     .aspectSquare {
       width: 35vw;


### PR DESCRIPTION
…n tablet

The tablet breakpoint (600-768px) had different sizes for building vs project poster frames: 40vw/300px vs 35vw/260px. Matched them so both sections render identical card sizes.

https://claude.ai/code/session_01U5jtXUP7RMFdKULRQu5pEy